### PR TITLE
Add missing frontmatter header

### DIFF
--- a/incidents/0008-arweave-downtime.md
+++ b/incidents/0008-arweave-downtime.md
@@ -1,3 +1,11 @@
+---
+name: "Orcfax Incident Report"
+title: "INCIDENT 0008 - Arweave Downtime"
+published: 2025-11-04
+status: "In Progress"
+trigger: "Anomalous system behaviors"
+---
+
 ## Initial Publish Date
 
 2025-11-04


### PR DESCRIPTION
Without [the standardized frontmatter header](https://github.com/orcfax/network-status/blob/31fed07d0f1f9d73cd0b00e81e88bbbf9d6e6184/incidents/0000-example.md?plain=1#L1-L7), the status index fails to detect key fields leading to duplicate incident reports being added to the rss feed.